### PR TITLE
Update README.md with correct GitHub username

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Build and maintain your own self-improving AI conventions system. Start with com
 
 ```bash
 # One-liner setup (installs uv if needed)
-curl -LsSf https://raw.githubusercontent.com/yourusername/cookiecutter-ai-conventions/main/bootstrap.sh | sh
+curl -LsSf https://raw.githubusercontent.com/safurrier/cookiecutter-ai-conventions-experimental/main/bootstrap.sh | sh
 
 # Or if you have uv installed
-uvx cookiecutter gh:yourusername/cookiecutter-ai-conventions
+uvx cookiecutter gh:safurrier/cookiecutter-ai-conventions-experimental
 ```
 
 Then:


### PR DESCRIPTION
## Summary
- Updates README installation commands to use actual GitHub username and repository name

## Changes
- Replace 'yourusername' → 'safurrier'
- Update repository name to 'cookiecutter-ai-conventions-experimental'

## Testing
- Verified URLs are now correct for both curl and uvx commands

Fixes #5