### PR TITLE
feat: Implement Aider provider integration

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -136,23 +136,72 @@ your-project/
 
 ## Aider
 
-Aider support through `.aider.conf.yml` is coming.
+Full Aider support with automatic convention loading.
 
-### Planned Integration
+### Installation
+When you select Aider as a provider, the template automatically creates:
+- `CONVENTIONS.md` - Main conventions file (automatically loaded)
+- `.aider.conf.yml` - Configuration with auto-loading setup
+- `docs/aider-setup.md` - Complete setup guide
+
+### How It Works
+
+#### Convention Loading
+- Aider automatically reads `CONVENTIONS.md` on startup
+- Domain files included as read-only context
+- No manual loading required
+
+#### Configuration
+The `.aider.conf.yml` file sets up:
 ```yaml
-# .aider.conf.yml
-conventions:
-  source: ~/.ai-conventions/
-  domains:
-    - python
-    - git
-    - testing
+# Auto-loaded files
+read: CONVENTIONS.md
+
+# Read-only domain files
+read-only:
+  - global.md
+  - domains/git/core.md
+  - domains/testing/core.md
+  # ... other selected domains
 ```
 
-### Current Workaround
-Use Aider's `--read` flag:
+### Features
+- ✅ Automatic convention loading
+- ✅ Domain-specific context
+- ✅ Test command integration
+- ✅ Learning capture support
+- ✅ Multiple model support
+- ✅ Git integration
+
+### File Structure
+```
+your-project/
+├── CONVENTIONS.md       # Main conventions (auto-loaded)
+├── .aider.conf.yml     # Aider configuration
+├── domains/            # Domain conventions
+│   ├── git/core.md
+│   ├── testing/core.md
+│   └── ...
+└── docs/
+    └── aider-setup.md  # Setup guide
+```
+
+### Best Practices
+- Let Aider automatically load conventions
+- Use chat mode to ask about standards
+- Configure test/lint commands in `.aider.conf.yml`
+- Keep CONVENTIONS.md concise and clear
+
+### Usage
 ```bash
-aider --read ~/.claude/CLAUDE.md
+# Just run aider - conventions load automatically
+aider
+
+# Work on specific files
+aider src/main.py tests/
+
+# Use a specific model
+aider --model gpt-4o
 ```
 
 ---
@@ -251,7 +300,7 @@ If you want to contribute a provider integration:
 | Claude   | ✅ | ✅ | ✅ | 8K tokens |
 | Cursor   | ✅ | ✅ | ❌ | Per-file |
 | Windsurf | ✅ | ✅ | ❌ | 12K total |
-| Aider    | 🚧 | ❌ | ❌ | Unlimited |
+| Aider    | ✅ | ✅ | ❌ | Unlimited |
 | Copilot  | ❌ | ❌ | ❌ | Limited |
 
 ---

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -102,6 +102,21 @@ def main():
                 if rule_file.stem not in ["main"] + selected_domains:
                     rule_file.unlink()
     
+    # Handle Aider provider files
+    if providers and "aider" not in providers:
+        # Remove Aider files if not selected
+        conventions_file = Path("CONVENTIONS.md")
+        if conventions_file.exists():
+            conventions_file.unlink()
+        
+        aider_conf_file = Path(".aider.conf.yml")
+        if aider_conf_file.exists():
+            aider_conf_file.unlink()
+        
+        aider_docs = Path("docs/aider-setup.md")
+        if aider_docs.exists():
+            aider_docs.unlink()
+    
     # Clean up learning capture commands if not enabled
     if not enable_learning:
         commands_dir = Path("commands")
@@ -157,7 +172,10 @@ def main():
         
         if "aider" in providers:
             print("\nAider setup:")
-            print("  Use --read flag with stdlib/")
+            print("  Your conventions are configured in:")
+            print("  - CONVENTIONS.md (automatically loaded)")
+            print("  - .aider.conf.yml (configuration)")
+            print("  Just run 'aider' to start coding!")
     
     print("\nNext steps:")
     print("  1. cd into your project directory")

--- a/tests/test_aider_provider.py
+++ b/tests/test_aider_provider.py
@@ -1,0 +1,203 @@
+"""Test Aider provider integration."""
+
+import pytest
+from pathlib import Path
+
+
+def test_aider_creates_conventions_md_file(cookies):
+    """Test that selecting Aider creates a CONVENTIONS.md file."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    assert result.exception is None
+    
+    # Check CONVENTIONS.md exists
+    conventions_file = result.project_path / "CONVENTIONS.md"
+    assert conventions_file.exists()
+    
+    # Check content includes project info and domains
+    content = conventions_file.read_text()
+    assert "# Coding Standards" in content
+    assert "Test AI Conventions" in content
+    assert "git" in content.lower()
+    assert "testing" in content.lower()
+
+
+def test_aider_creates_conf_yml_file(cookies):
+    """Test that selecting Aider creates .aider.conf.yml file."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check .aider.conf.yml exists
+    conf_file = result.project_path / ".aider.conf.yml"
+    assert conf_file.exists()
+    
+    # Check content references CONVENTIONS.md
+    content = conf_file.read_text()
+    assert "read: CONVENTIONS.md" in content or "read-only: CONVENTIONS.md" in content
+
+
+def test_aider_conventions_includes_all_domains(cookies):
+    """Test that CONVENTIONS.md includes all selected domains."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing,writing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    conventions_file = result.project_path / "CONVENTIONS.md"
+    content = conventions_file.read_text()
+    
+    # Check git conventions
+    assert "## Git Conventions" in content or "## Version Control" in content
+    assert "conventional commits" in content.lower() or "commit format" in content.lower()
+    
+    # Check testing conventions
+    assert "## Testing" in content
+    assert "pytest" in content.lower()
+    
+    # Check writing conventions
+    assert "## Documentation" in content or "## Writing" in content
+    assert "docstrings" in content.lower() or "documentation" in content.lower()
+
+
+def test_aider_conf_yml_includes_extra_read_files(cookies):
+    """Test that .aider.conf.yml includes domain files when configured."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    conf_file = result.project_path / ".aider.conf.yml"
+    content = conf_file.read_text()
+    
+    # Should list CONVENTIONS.md and potentially domain files
+    assert "CONVENTIONS.md" in content
+    # Optionally could include: domains/git/core.md, etc.
+
+
+def test_aider_not_selected_no_files_created(cookies):
+    """Test that Aider files are not created when not selected."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "claude"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check no Aider files exist
+    assert not (result.project_path / "CONVENTIONS.md").exists()
+    assert not (result.project_path / ".aider.conf.yml").exists()
+
+
+def test_aider_setup_documentation_created(cookies):
+    """Test that Aider setup documentation is created."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check Aider setup docs exist
+    aider_docs = result.project_path / "docs" / "aider-setup.md"
+    assert aider_docs.exists()
+    content = aider_docs.read_text()
+    assert "Aider Setup Guide" in content
+    assert "CONVENTIONS.md" in content
+    assert ".aider.conf.yml" in content
+    assert "--read" in content
+
+
+def test_aider_learning_capture_integration(cookies):
+    """Test that learning capture is mentioned when enabled."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check CONVENTIONS.md mentions learning capture
+    conventions_file = result.project_path / "CONVENTIONS.md"
+    content = conventions_file.read_text()
+    assert "staging/learnings.md" in content or "Learning Capture" in content
+    
+    # Check .aider.conf.yml might include staging/learnings.md
+    conf_file = result.project_path / ".aider.conf.yml"
+    content = conf_file.read_text()
+    # Could optionally include staging/learnings.md in read list
+
+
+def test_aider_without_learning_capture(cookies):
+    """Test Aider configuration when learning capture is disabled."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": False,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check no learning capture mentions
+    conventions_file = result.project_path / "CONVENTIONS.md"
+    content = conventions_file.read_text()
+    assert "capture-learning" not in content
+    assert "staging/learnings" not in content

--- a/{{cookiecutter.project_slug}}/.aider.conf.yml
+++ b/{{cookiecutter.project_slug}}/.aider.conf.yml
@@ -1,0 +1,37 @@
+# Aider configuration file
+# https://aider.chat/docs/config.html
+
+# Automatically read conventions file to provide context
+read: CONVENTIONS.md
+
+# Include domain-specific conventions
+{%- set domains = cookiecutter.default_domains.split(',') %}
+read-only:
+  - global.md
+{%- for domain in domains %}
+  - domains/{{ domain.strip() }}/core.md
+{%- endfor %}
+{%- if cookiecutter.enable_learning_capture %}
+  - staging/learnings.md
+{%- endif %}
+
+# Model preferences (optional)
+# model: gpt-4o
+# edit-format: diff
+
+# Git configuration
+auto-commits: false
+commit: false
+
+# Output preferences
+pretty: true
+stream: true
+
+# Testing configuration
+test-cmd: {% if "testing" in domains %}pytest{% else %}# Configure your test command{% endif %}
+
+# Linting configuration  
+lint-cmd: {% if "python" in domains %}ruff check{% else %}# Configure your lint command{% endif %}
+
+# Additional settings
+encoding: utf-8

--- a/{{cookiecutter.project_slug}}/CONVENTIONS.md
+++ b/{{cookiecutter.project_slug}}/CONVENTIONS.md
@@ -1,0 +1,127 @@
+# Coding Standards
+
+This document defines the coding standards and conventions for {{ cookiecutter.project_name }}.
+
+Unless otherwise specified, follow language-specific best practices (PEP8 for Python, ESLint for JavaScript, etc.).
+
+## Project Information
+
+- **Project**: {{ cookiecutter.project_name }}
+- **Author**: {{ cookiecutter.author_name }}
+- **Conventions Source**: domains/ directory
+
+{%- set domains = cookiecutter.default_domains.split(',') %}
+
+{%- if "git" in domains %}
+
+## Git Conventions
+
+### Commit Messages
+- Use conventional commit format: `type(scope): description`
+- Types: feat, fix, docs, style, refactor, test, chore
+- Keep subject line under 50 characters
+- Use imperative mood ("Add feature" not "Added feature")
+
+### Branch Naming
+- feature/* - New features
+- fix/* - Bug fixes
+- docs/* - Documentation changes
+
+### Pull Requests
+- Clear, descriptive titles
+- Link related issues
+- Include test plan
+
+For complete git conventions, see: domains/git/core.md
+{%- endif %}
+
+{%- if "testing" in domains %}
+
+## Testing
+
+### Framework
+- Use pytest for Python testing (not unittest)
+- Follow progressive testing approach: E2E → Integration → Unit
+
+### Test Structure
+```python
+def test_behavior_when_condition():
+    """Test that behavior occurs when condition is met."""
+    # Arrange - Set up test data
+    # Act - Execute the behavior  
+    # Assert - Verify the outcome
+```
+
+### Requirements
+- Each new function needs comprehensive tests
+- Include positive ("happy path") test cases
+- Include negative (error-handling) test cases
+- Use descriptive test names
+
+For complete testing conventions, see: domains/testing/core.md
+{%- endif %}
+
+{%- if "writing" in domains %}
+
+## Documentation
+
+### Code Documentation
+- Include detailed docstrings for all public functions
+- Use triple double quotes ("""Docstring""")
+- Include type hints in function signatures
+- Document edge cases and assumptions
+
+### Technical Writing
+- Start with the problem, not the solution
+- Use concrete examples
+- Active voice
+- Progressive disclosure of complexity
+
+For complete writing conventions, see: domains/writing/core.md
+{%- endif %}
+
+## Code Layout
+
+### General Principles
+- Keep functions short and focused
+- Limit line length appropriately for the language
+- Group related functionality
+- Clear separation of concerns
+
+### Naming
+- Use descriptive, meaningful names
+- Follow language-specific conventions:
+  - Python: snake_case for functions/variables, PascalCase for classes
+  - JavaScript: camelCase for functions/variables, PascalCase for classes
+- UPPER_CASE for constants
+
+## Security
+
+- Never hardcode secrets or credentials
+- Use environment variables for sensitive data
+- Validate all external input
+- Follow principle of least privilege
+
+{%- if cookiecutter.enable_learning_capture %}
+
+## Learning Capture
+
+This project uses a learning capture system to evolve conventions:
+- New insights are captured in staging/learnings.md
+- Use commands/capture-learning.py to record patterns
+- Periodically review and promote stable patterns
+
+When you notice repeated patterns or corrections, capture them for future reference.
+{%- endif %}
+
+## Additional Resources
+
+For detailed, domain-specific conventions, refer to:
+{%- for domain in domains %}
+- domains/{{ domain.strip() }}/core.md - {{ domain.strip()|title }} conventions
+{%- endfor %}
+- global.md - Universal patterns
+
+---
+
+These conventions are living documents. They evolve based on team experience and project needs.

--- a/{{cookiecutter.project_slug}}/docs/aider-setup.md
+++ b/{{cookiecutter.project_slug}}/docs/aider-setup.md
@@ -1,0 +1,247 @@
+# Aider Setup Guide
+
+This guide helps you use your AI conventions with Aider, the AI pair programming tool.
+
+## Installation
+
+Your conventions are automatically configured for Aider with:
+- `CONVENTIONS.md` file in the project root
+- `.aider.conf.yml` configuration file
+
+## Quick Start
+
+1. **Install Aider**:
+   ```bash
+   pip install aider-chat
+   ```
+
+2. **Run Aider** in your project:
+   ```bash
+   cd {{ cookiecutter.project_slug }}
+   aider
+   ```
+
+   Aider will automatically load your conventions from `CONVENTIONS.md`.
+
+## How It Works
+
+### Convention Loading
+
+Aider uses two main files:
+
+1. **CONVENTIONS.md** - Your project coding standards
+   - Automatically loaded by Aider
+   - Provides context for all AI interactions
+   - Includes domain-specific conventions
+
+2. **.aider.conf.yml** - Aider configuration
+   - Sets up automatic convention loading
+   - Configures read-only domain files
+   - Defines project preferences
+
+### File Structure
+
+```
+{{ cookiecutter.project_slug }}/
+├── CONVENTIONS.md       # Main conventions (auto-loaded)
+├── .aider.conf.yml     # Aider configuration
+├── domains/            # Domain-specific conventions
+│   {%- set domains = cookiecutter.default_domains.split(',') %}
+│   {%- for domain in domains %}
+│   ├── {{ domain.strip() }}/
+│   │   └── core.md
+{%- endfor %}
+│   └── ...
+├── global.md           # Universal patterns
+{%- if cookiecutter.enable_learning_capture %}
+└── staging/
+    └── learnings.md    # Captured patterns
+{%- endif %}
+```
+
+## Command Line Usage
+
+### Basic Commands
+
+```bash
+# Start Aider with your conventions
+aider
+
+# Work on specific files
+aider src/main.py tests/test_main.py
+
+# Use a specific model
+aider --model gpt-4o
+
+# Read additional context
+aider --read docs/api-design.md
+```
+
+### Working with Conventions
+
+Your conventions are automatically loaded, but you can:
+
+```bash
+# Explicitly reference conventions
+aider --read CONVENTIONS.md --read-only domains/
+
+# Focus on specific domains
+aider --read-only domains/testing/core.md
+```
+
+## Configuration Details
+
+Your `.aider.conf.yml` includes:
+
+```yaml
+# Auto-loaded files
+read: CONVENTIONS.md
+
+# Read-only domain files
+read-only:
+  - global.md
+{%- for domain in domains %}
+  - domains/{{ domain.strip() }}/core.md
+{%- endfor %}
+
+# Project settings
+auto-commits: false
+test-cmd: {% if "testing" in domains %}pytest{% else %}# your test command{% endif %}
+```
+
+## Best Practices
+
+### 1. Let Aider Read Conventions
+
+Aider automatically loads `CONVENTIONS.md`. Trust it to:
+- Follow your coding standards
+- Apply domain patterns
+- Maintain consistency
+
+### 2. Use Chat Mode Effectively
+
+```bash
+# Ask about conventions
+> What are our git commit conventions?
+
+# Request convention-following code
+> Create a test following our testing patterns
+
+# Validate against conventions
+> Does this code follow our standards?
+```
+
+### 3. Leverage Domain Knowledge
+
+Your domains are loaded as read-only context:
+{%- for domain in domains %}
+{% if domain.strip() == "git" %}
+- **Git**: Commit messages, branching, workflows
+{%- elif domain.strip() == "testing" %}
+- **Testing**: Pytest patterns, test structure
+{%- elif domain.strip() == "writing" %}
+- **Writing**: Documentation style, clarity
+{%- endif %}
+{%- endfor %}
+
+{% if cookiecutter.enable_learning_capture %}
+## Learning Capture
+
+When you notice patterns:
+
+1. **During Aider session**:
+   ```
+   > I notice we always validate input this way...
+   ```
+
+2. **Capture the learning**:
+   ```bash
+   ./commands/capture-learning.py
+   ```
+
+3. **Review periodically**:
+   ```bash
+   ./commands/review-learnings.py
+   ```
+{% endif %}
+
+## Advanced Usage
+
+### Custom Configuration
+
+Modify `.aider.conf.yml` for:
+
+```yaml
+# Different model
+model: claude-3-opus
+
+# Editor integration
+editor-model: gpt-4o
+
+# Voice mode
+voice-language: en
+```
+
+### Project-Specific Context
+
+Add project files to context:
+
+```yaml
+read:
+  - CONVENTIONS.md
+  - docs/architecture.md
+  - API.md
+```
+
+### Testing Integration
+
+Aider can run tests automatically:
+
+```yaml
+test-cmd: pytest tests/
+auto-test: true
+```
+
+## Troubleshooting
+
+### Conventions Not Loading?
+
+1. Check file exists: `CONVENTIONS.md`
+2. Verify `.aider.conf.yml` syntax
+3. Run with explicit read: `aider --read CONVENTIONS.md`
+
+### Too Much Context?
+
+1. Use `--read-only` for reference files
+2. Limit to specific domains
+3. Use `.aiderignore` file
+
+### Model Selection
+
+Choose models based on task:
+- `gpt-4o`: General coding
+- `claude-3-opus`: Complex reasoning
+- `gpt-3.5-turbo`: Quick tasks
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `aider` | Start with conventions |
+| `aider --help` | Show all options |
+| `aider --read FILE` | Add file to context |
+| `aider --read-only DIR/` | Add directory as reference |
+| `aider --model MODEL` | Use specific model |
+| `aider --test` | Run tests after changes |
+
+## Next Steps
+
+1. Install Aider: `pip install aider-chat`
+2. Navigate to your project
+3. Run `aider` - conventions load automatically
+4. Start coding with AI assistance!
+
+For more information:
+- [Aider Documentation](https://aider.chat/)
+- [Configuration Options](https://aider.chat/docs/config.html)
+- Your conventions: `CONVENTIONS.md`


### PR DESCRIPTION
## Summary
- Implement full Aider provider integration with automatic convention loading
- Aider users can now just run `aider` and conventions are automatically loaded

## Test plan
- [x] Run test suite: `uv run pytest tests/test_aider_provider.py -xvs`
- [x] All 8 tests passing
- [x] E2E test with cookiecutter generation
- [x] Verify CONVENTIONS.md is properly generated with selected domains
- [x] Verify .aider.conf.yml includes correct read/read-only files
- [x] Verify cleanup works when Aider not selected

🤖 Generated with [Claude Code](https://claude.ai/code)