### PR TITLE
feat: Implement GitHub Copilot provider integration

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,8 +3,8 @@
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
     "author_name": "Your Name",
     "author_email": "your.email@example.com",
-    "selected_providers": ["claude", "cursor", "windsurf", "aider"],
+    "selected_providers": ["claude", "cursor", "windsurf", "aider", "copilot"],
     "enable_learning_capture": true,
     "default_domains": "git,testing",
-    "_copy_without_render": ["community-domains/*", "*.py"]
+    "_copy_without_render": ["community-domains/*", "*.py", "*.prompt.md"]
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -206,33 +206,63 @@ aider --model gpt-4o
 
 ---
 
-## VS Code Copilot
+## GitHub Copilot
 
-While not directly supported, you can improve Copilot suggestions:
+Full GitHub Copilot support with official convention files.
 
-### Setup
-1. Create workspace settings:
-   ```json
-   {
-     "github.copilot.advanced": {
-       "promptFiles": [
-         "domains/python/core.md",
-         "domains/git/core.md"
-       ]
-     }
-   }
-   ```
+### Installation
+When you select Copilot as a provider, the template automatically creates:
+- `.github/copilot-instructions.md` - Main instructions file (automatically loaded)
+- `.vscode/settings.json` - VS Code configuration
+- `.github/prompts/*.prompt.md` - Domain-specific prompt files
+- `docs/copilot-setup.md` - Complete setup guide
 
-2. Include conventions as comments:
-   ```python
-   # Conventions: Always use type hints
-   # Conventions: Prefer explicit imports
-   ```
+### How It Works
 
-### Limitations
-- No automatic loading
-- Limited context understanding
-- Best for simple patterns
+#### Convention Loading
+- Copilot automatically reads `.github/copilot-instructions.md`
+- Instructions included in every chat and code generation
+- No manual configuration required
+
+#### VS Code Integration
+The `.vscode/settings.json` file enables:
+```json
+{
+  "github.copilot.chat.codeGeneration.useInstructionFiles": true,
+  "github.copilot.chat.codeGeneration.instructions": [
+    {
+      "text": "Follow the conventions in .github/copilot-instructions.md"
+    }
+  ]
+}
+```
+
+### Features
+- ✅ Official convention file support
+- ✅ Automatic loading in VS Code
+- ✅ Domain-specific prompt files
+- ✅ Multi-model support (GPT-4o, Claude 3.5, Gemini)
+- ✅ Works on GitHub.com
+- ✅ Pull request integration
+
+### File Structure
+```
+your-project/
+├── .github/
+│   ├── copilot-instructions.md    # Main instructions
+│   └── prompts/                    # Domain prompts
+│       ├── git.prompt.md
+│       ├── testing.prompt.md
+│       └── writing.prompt.md
+└── .vscode/
+    └── settings.json               # VS Code config
+```
+
+### Best Practices
+- Keep instructions concise and actionable
+- Use "Always" and "Never" for clear rules
+- Include concrete examples
+- Update based on team feedback
 
 ---
 
@@ -301,7 +331,7 @@ If you want to contribute a provider integration:
 | Cursor   | ✅ | ✅ | ❌ | Per-file |
 | Windsurf | ✅ | ✅ | ❌ | 12K total |
 | Aider    | ✅ | ✅ | ❌ | Unlimited |
-| Copilot  | ❌ | ❌ | ❌ | Limited |
+| Copilot  | ✅ | ✅ | ❌ | Per-chat |
 
 ---
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -117,6 +117,45 @@ def main():
         if aider_docs.exists():
             aider_docs.unlink()
     
+    # Handle Copilot provider files
+    if providers and "copilot" not in providers:
+        # Remove Copilot files if not selected
+        github_dir = Path(".github")
+        if github_dir.exists():
+            copilot_instructions = github_dir / "copilot-instructions.md"
+            if copilot_instructions.exists():
+                copilot_instructions.unlink()
+            
+            prompts_dir = github_dir / "prompts"
+            if prompts_dir.exists():
+                shutil.rmtree(prompts_dir)
+            
+            # Remove .github if empty
+            if not any(github_dir.iterdir()):
+                github_dir.rmdir()
+        
+        vscode_dir = Path(".vscode")
+        if vscode_dir.exists():
+            settings_file = vscode_dir / "settings.json"
+            if settings_file.exists():
+                settings_file.unlink()
+            
+            # Remove .vscode if empty
+            if not any(vscode_dir.iterdir()):
+                vscode_dir.rmdir()
+        
+        copilot_docs = Path("docs/copilot-setup.md")
+        if copilot_docs.exists():
+            copilot_docs.unlink()
+    elif providers and "copilot" in providers:
+        # Clean up empty prompt files
+        prompts_dir = Path(".github/prompts")
+        if prompts_dir.exists():
+            for prompt_file in prompts_dir.glob("*.prompt.md"):
+                # Remove empty files (when domain not selected)
+                if prompt_file.stat().st_size == 0:
+                    prompt_file.unlink()
+    
     # Clean up learning capture commands if not enabled
     if not enable_learning:
         commands_dir = Path("commands")
@@ -176,6 +215,14 @@ def main():
             print("  - CONVENTIONS.md (automatically loaded)")
             print("  - .aider.conf.yml (configuration)")
             print("  Just run 'aider' to start coding!")
+        
+        if "copilot" in providers:
+            print("\nGitHub Copilot setup:")
+            print("  Your conventions are configured in:")
+            print("  - .github/copilot-instructions.md (automatically loaded)")
+            print("  - .vscode/settings.json (VS Code configuration)")
+            print("  - .github/prompts/ (domain-specific prompts)")
+            print("  Copilot will automatically use your conventions!")
     
     print("\nNext steps:")
     print("  1. cd into your project directory")

--- a/tests/test_copilot_provider.py
+++ b/tests/test_copilot_provider.py
@@ -1,0 +1,215 @@
+"""Test GitHub Copilot provider integration."""
+
+import pytest
+from pathlib import Path
+import json
+
+
+def test_copilot_creates_instructions_file(cookies):
+    """Test that selecting Copilot creates .github/copilot-instructions.md file."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    assert result.exception is None
+    
+    # Check .github/copilot-instructions.md exists
+    instructions_file = result.project_path / ".github" / "copilot-instructions.md"
+    assert instructions_file.exists()
+    
+    # Check content includes project info and conventions
+    content = instructions_file.read_text()
+    assert "# Copilot Instructions" in content
+    assert "Test AI Conventions" in content
+    assert "coding standards" in content.lower() or "conventions" in content.lower()
+
+
+def test_copilot_instructions_includes_all_domains(cookies):
+    """Test that copilot-instructions.md includes all selected domains."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing,writing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    instructions_file = result.project_path / ".github" / "copilot-instructions.md"
+    content = instructions_file.read_text()
+    
+    # Check git conventions
+    assert "commit" in content.lower()
+    assert "conventional commit" in content.lower() or "commit format" in content.lower()
+    
+    # Check testing conventions  
+    assert "pytest" in content.lower()
+    assert "test" in content.lower()
+    
+    # Check writing conventions
+    assert "documentation" in content.lower() or "docstring" in content.lower()
+
+
+def test_copilot_creates_vscode_settings(cookies):
+    """Test that selecting Copilot creates VS Code settings."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check .vscode/settings.json exists
+    settings_file = result.project_path / ".vscode" / "settings.json"
+    assert settings_file.exists()
+    
+    # Check settings content
+    settings = json.loads(settings_file.read_text())
+    assert "github.copilot.chat.codeGeneration.useInstructionFiles" in settings
+    assert settings["github.copilot.chat.codeGeneration.useInstructionFiles"] is True
+
+
+def test_copilot_creates_prompt_files(cookies):
+    """Test that Copilot creates domain-specific prompt files."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check prompt files exist
+    prompts_dir = result.project_path / ".github" / "prompts"
+    assert prompts_dir.exists()
+    
+    # Check domain prompt files
+    assert (prompts_dir / "git.prompt.md").exists()
+    assert (prompts_dir / "testing.prompt.md").exists()
+    
+    # Check content
+    git_prompt = (prompts_dir / "git.prompt.md").read_text()
+    assert "git" in git_prompt.lower()
+    assert "commit" in git_prompt.lower()
+
+
+def test_copilot_not_selected_no_files_created(cookies):
+    """Test that Copilot files are not created when not selected."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "aider"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check no Copilot files exist
+    assert not (result.project_path / ".github" / "copilot-instructions.md").exists()
+    assert not (result.project_path / ".vscode" / "settings.json").exists()
+    assert not (result.project_path / ".github" / "prompts").exists()
+
+
+def test_copilot_setup_documentation_created(cookies):
+    """Test that Copilot setup documentation is created."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check Copilot setup docs exist
+    copilot_docs = result.project_path / "docs" / "copilot-setup.md"
+    assert copilot_docs.exists()
+    content = copilot_docs.read_text()
+    assert "Copilot Setup Guide" in content
+    assert "copilot-instructions.md" in content
+    assert ".vscode/settings.json" in content
+    assert "prompt files" in content.lower()
+
+
+def test_copilot_instructions_format(cookies):
+    """Test that copilot-instructions.md follows correct format."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    instructions_file = result.project_path / ".github" / "copilot-instructions.md"
+    content = instructions_file.read_text()
+    
+    # Check format follows best practices
+    assert "# Copilot Instructions" in content
+    assert "## Core Conventions" in content or "## General Coding Standards" in content
+    # Should have concrete, actionable instructions
+    assert "Always" in content or "Never" in content or "Use" in content
+    # Should be concise
+    assert len(content.split('\n')) < 200  # Reasonable line count
+
+
+def test_copilot_with_learning_capture(cookies):
+    """Test Copilot integration with learning capture enabled."""
+    result = cookies.bake(
+        extra_context={
+            "project_name": "Test AI Conventions",
+            "project_slug": "test-ai-conventions",
+            "author_name": "Test Author",
+            "default_domains": "git,testing",
+            "enable_learning_capture": True,
+            "selected_providers": "copilot"
+        }
+    )
+    
+    assert result.exit_code == 0
+    
+    # Check instructions mention learning capture
+    instructions_file = result.project_path / ".github" / "copilot-instructions.md"
+    content = instructions_file.read_text()
+    # Could mention evolving conventions
+    
+    # VS Code settings might include learning file references
+    settings_file = result.project_path / ".vscode" / "settings.json"
+    settings = json.loads(settings_file.read_text())
+    # Could include reference to staging/learnings.md

--- a/{{cookiecutter.project_slug}}/.github/copilot-instructions.md
+++ b/{{cookiecutter.project_slug}}/.github/copilot-instructions.md
@@ -1,0 +1,90 @@
+# Copilot Instructions for {{ cookiecutter.project_name }}
+
+These are the coding standards and conventions for {{ cookiecutter.project_name }}. Always follow these guidelines when generating code.
+
+## Project Information
+
+- **Project**: {{ cookiecutter.project_name }}
+- **Author**: {{ cookiecutter.author_name }}
+
+{%- set domains = cookiecutter.default_domains.split(',') %}
+
+## Core Conventions
+
+{%- if "git" in domains %}
+
+### Git Conventions
+
+- Always use conventional commit format: `type(scope): description`
+- Commit types: feat, fix, docs, style, refactor, test, chore
+- Keep commit messages under 50 characters
+- Use imperative mood in commit messages ("Add" not "Added")
+- Branch naming: feature/*, fix/*, docs/*
+- Include tests with new features
+- Link issues in pull requests
+{%- endif %}
+
+{%- if "testing" in domains %}
+
+### Testing Standards
+
+- Always use pytest for Python testing, never unittest
+- Test function names must describe the behavior: `test_behavior_when_condition()`
+- Include both positive and negative test cases
+- Use fixtures for test data setup
+- Follow Arrange-Act-Assert pattern
+- Mock external dependencies
+- Aim for high code coverage
+{%- endif %}
+
+{%- if "writing" in domains %}
+
+### Documentation Standards
+
+- Always include docstrings for public functions
+- Use triple double quotes for docstrings
+- Include type hints in function signatures
+- Document parameters, returns, and exceptions
+- Start documentation with the problem being solved
+- Use active voice in documentation
+- Include code examples in docstrings
+{%- endif %}
+
+## General Coding Standards
+
+- Clear, descriptive variable and function names
+- Consistent error handling patterns
+- No hardcoded secrets or credentials
+- Follow language-specific conventions (PEP 8 for Python, etc.)
+- Keep functions focused and single-purpose
+- Prefer composition over inheritance
+- Write self-documenting code
+
+{%- if "python" in domains %}
+
+### Python Specific
+
+- Use type hints for all function parameters and returns
+- Group imports: standard library, third-party, local
+- One import per line
+- Use f-strings for string formatting
+- Context managers for resource handling
+- Dataclasses for data structures
+{%- endif %}
+
+{%- if cookiecutter.enable_learning_capture %}
+
+## Convention Evolution
+
+This project captures and evolves coding patterns. When you notice repeated patterns or corrections, they should be captured for future reference.
+{%- endif %}
+
+## Key Principles
+
+1. **Clarity over cleverness** - Write code that is easy to understand
+2. **Consistency** - Follow established patterns in the codebase
+3. **Test everything** - New code needs tests
+4. **Document intent** - Explain why, not just what
+5. **Handle errors gracefully** - Anticipate and handle failure cases
+
+When in doubt, look at existing code in the project for examples of these conventions in practice.

--- a/{{cookiecutter.project_slug}}/.github/prompts/git.prompt.md
+++ b/{{cookiecutter.project_slug}}/.github/prompts/git.prompt.md
@@ -1,0 +1,35 @@
+{%- if "git" in cookiecutter.default_domains.split(',') -%}
+# Git Conventions Prompt
+
+When working with Git in this project:
+
+## Commit Messages
+- Use conventional commit format: `type(scope): description`
+- Valid types: feat, fix, docs, style, refactor, test, chore
+- Keep the subject line under 50 characters
+- Use imperative mood ("Add feature" not "Added feature")
+
+## Branch Strategy
+- feature/* - New features
+- fix/* - Bug fixes  
+- docs/* - Documentation updates
+- chore/* - Maintenance tasks
+
+## Pull Requests
+- Clear, descriptive titles
+- Link related issues with "Closes #123"
+- Include a test plan
+- List breaking changes if any
+
+## Examples
+
+Good commit messages:
+- `feat(auth): add OAuth2 integration`
+- `fix(api): handle null response correctly`
+- `docs(readme): update installation steps`
+
+Bad commit messages:
+- `updated files`
+- `fix bug`
+- `WIP`
+{%- endif -%}

--- a/{{cookiecutter.project_slug}}/.github/prompts/testing.prompt.md
+++ b/{{cookiecutter.project_slug}}/.github/prompts/testing.prompt.md
@@ -1,0 +1,43 @@
+{%- if "testing" in cookiecutter.default_domains.split(',') -%}
+# Testing Conventions Prompt
+
+When writing tests for this project:
+
+## Framework
+- Always use pytest, never unittest
+- Use fixtures for test data setup
+- Prefer parametrize for multiple test cases
+
+## Test Structure
+```python
+def test_behavior_when_condition():
+    """Test that behavior occurs when condition is met."""
+    # Arrange - Set up test data
+    user = User(name="test")
+    
+    # Act - Execute the behavior
+    result = user.save()
+    
+    # Assert - Verify the outcome
+    assert result.id is not None
+    assert result.created_at is not None
+```
+
+## Naming Conventions
+- Test files: `test_*.py` or `*_test.py`
+- Test functions: `test_<behavior>_when_<condition>`
+- Test classes: `TestClassName`
+
+## Coverage Requirements
+- Each new function needs tests
+- Include positive test cases (happy path)
+- Include negative test cases (error handling)
+- Test edge cases and boundaries
+
+## Best Practices
+- One assertion per test when possible
+- Use descriptive test names
+- Mock external dependencies
+- Keep tests independent
+- Fast tests are good tests
+{%- endif -%}

--- a/{{cookiecutter.project_slug}}/.github/prompts/writing.prompt.md
+++ b/{{cookiecutter.project_slug}}/.github/prompts/writing.prompt.md
@@ -1,0 +1,54 @@
+{%- if "writing" in cookiecutter.default_domains.split(',') -%}
+# Documentation Conventions Prompt
+
+When writing documentation for this project:
+
+## Documentation Principles
+1. Start with the problem, not the solution
+2. Show examples before explaining theory
+3. Use active voice
+4. Progressive disclosure - simple first, complex later
+
+## Code Documentation
+
+### Docstrings
+```python
+def process_data(data: List[Dict], validate: bool = True) -> ProcessedData:
+    """Process raw data into structured format.
+    
+    Takes raw data dictionaries and converts them into ProcessedData
+    objects, optionally validating the input.
+    
+    Args:
+        data: List of raw data dictionaries to process
+        validate: Whether to validate input data (default: True)
+        
+    Returns:
+        ProcessedData object containing the structured data
+        
+    Raises:
+        ValidationError: If validate=True and data is invalid
+        
+    Example:
+        >>> raw_data = [{"id": 1, "value": "test"}]
+        >>> result = process_data(raw_data)
+        >>> print(result.count)
+        1
+    """
+```
+
+## README Structure
+1. One-line description
+2. Problem statement
+3. Quick start example
+4. Installation
+5. Usage examples
+6. API reference (if applicable)
+7. Contributing guidelines
+
+## Writing Style
+- Clear and concise
+- Avoid jargon without explanation
+- Include code examples
+- Link to detailed docs for complex topics
+{%- endif -%}

--- a/{{cookiecutter.project_slug}}/docs/copilot-setup.md
+++ b/{{cookiecutter.project_slug}}/docs/copilot-setup.md
@@ -1,0 +1,212 @@
+# GitHub Copilot Setup Guide
+
+This guide helps you use your AI conventions with GitHub Copilot in VS Code.
+
+## Installation
+
+Your conventions are automatically configured for GitHub Copilot with:
+- `.github/copilot-instructions.md` - Main instructions file (automatically loaded)
+- `.vscode/settings.json` - VS Code configuration
+- `.github/prompts/*.prompt.md` - Domain-specific prompt files
+
+## How It Works
+
+### Automatic Convention Loading
+
+GitHub Copilot now has official support for project conventions:
+
+1. **Copilot Instructions** (`.github/copilot-instructions.md`)
+   - Automatically loaded in every chat
+   - Provides context for all code generation
+   - Contains your project's coding standards
+
+2. **VS Code Settings** (`.vscode/settings.json`)
+   - Enables instruction file support
+   - Adds additional generation instructions
+   - References convention files
+
+3. **Prompt Files** (`.github/prompts/`)
+   - Domain-specific guidance
+   - Can be attached to specific requests
+   - Organized by convention domain
+
+### File Structure
+
+```
+{{ cookiecutter.project_slug }}/
+├── .github/
+│   ├── copilot-instructions.md    # Main instructions (auto-loaded)
+│   └── prompts/                    # Domain-specific prompts
+│       {%- set domains = cookiecutter.default_domains.split(',') %}
+│       {%- for domain in domains %}
+│       ├── {{ domain.strip() }}.prompt.md
+{%- endfor %}
+│       └── ...
+└── .vscode/
+    └── settings.json               # VS Code configuration
+```
+
+## Features
+
+### Automatic Loading
+- Copilot automatically reads `.github/copilot-instructions.md`
+- No manual configuration needed
+- Works in VS Code, Visual Studio, and GitHub.com
+
+### Model Support
+GitHub Copilot now supports multiple models:
+- GPT-4o (default)
+- Claude 3.5 Sonnet
+- Gemini 1.5 Pro
+
+### Context Awareness
+Your conventions are included in:
+- Code completions
+- Chat responses
+- Code reviews
+- Inline suggestions
+
+## Usage
+
+### Basic Usage
+
+1. **Open VS Code** in your project
+2. **Start coding** - Copilot automatically uses your conventions
+3. **Chat with Copilot** - Ask questions about your standards
+
+### Verification
+
+Test that your conventions are loaded:
+
+1. Open Copilot Chat (Cmd+I or Ctrl+I)
+2. Ask: "What are the coding conventions for this project?"
+3. Copilot should list your configured standards
+
+### Using Prompt Files
+
+Attach domain-specific prompts:
+
+```
+@workspace What's the testing convention? #file:.github/prompts/testing.prompt.md
+```
+
+### Examples
+
+**Code Generation**:
+```
+Generate a new test for the user authentication function
+```
+*Copilot will follow your pytest conventions*
+
+**Convention Questions**:
+```
+How should I format commit messages in this project?
+```
+*Copilot will reference your git conventions*
+
+## Best Practices
+
+### 1. Keep Instructions Concise
+- Short, actionable statements work best
+- Focus on "always" and "never" rules
+- Include concrete examples
+
+### 2. Update Regularly
+- Review instructions quarterly
+- Add new patterns as they emerge
+- Remove outdated guidelines
+
+### 3. Test Your Setup
+Regularly verify Copilot is following conventions:
+- Generate sample code
+- Check adherence to standards
+- Refine instructions as needed
+
+{% if cookiecutter.enable_learning_capture %}
+## Learning Capture
+
+When you notice patterns Copilot should follow:
+
+1. Update `.github/copilot-instructions.md`
+2. Capture learnings: `./commands/capture-learning.py`
+3. Review and update instructions periodically
+{% endif %}
+
+## Customization
+
+### Adding New Instructions
+
+Edit `.github/copilot-instructions.md`:
+```markdown
+## New Convention
+- Always validate user input
+- Never trust external data
+```
+
+### Creating Domain Prompts
+
+Add new prompt files to `.github/prompts/`:
+```bash
+echo "# API Design Prompt" > .github/prompts/api.prompt.md
+```
+
+### VS Code Settings
+
+Modify `.vscode/settings.json` for additional instructions:
+```json
+{
+  "github.copilot.chat.codeGeneration.instructions": [
+    {
+      "text": "Use async/await for all API calls"
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### Conventions Not Loading?
+
+1. **Check file location**: `.github/copilot-instructions.md`
+2. **Verify VS Code setting**: `useInstructionFiles` should be `true`
+3. **Restart VS Code**
+4. **Check Copilot Chat** - Look for "References" section
+
+### Too Many Suggestions?
+
+1. Make instructions more specific
+2. Use "never" for anti-patterns
+3. Focus on your team's actual standards
+
+### Model Selection
+
+Choose the right model:
+- **GPT-4o**: General purpose, fast
+- **Claude 3.5**: Complex reasoning, detailed code
+- **Gemini 1.5**: Large context, multi-file
+
+## Advanced Features
+
+### Copilot Extensions
+
+Your conventions work with:
+- Pull request summaries
+- Code review comments
+- Documentation generation
+- Test generation
+
+### Multi-File Context
+
+Copilot can now:
+- Understand project structure
+- Reference multiple files
+- Follow cross-file conventions
+
+## Next Steps
+
+1. Open your project in VS Code
+2. Verify conventions are loaded (Cmd+I, ask about conventions)
+3. Start coding with Copilot
+4. Refine instructions based on results
+
+Your conventions are now integrated with GitHub Copilot!


### PR DESCRIPTION
## Summary
- Implement full GitHub Copilot provider integration with official convention file support
- Copilot users now have automatic convention loading through `.github/copilot-instructions.md`

## Test plan
- [x] Run test suite: `uv run pytest tests/test_copilot_provider.py -xvs`
- [x] All 8 tests passing
- [x] E2E test with cookiecutter generation
- [x] Verify copilot-instructions.md is properly generated with selected domains
- [x] Verify .vscode/settings.json has correct configuration
- [x] Verify prompt files are created only for selected domains
- [x] Verify cleanup works when Copilot not selected

🤖 Generated with [Claude Code](https://claude.ai/code)