### PR TITLE
refactor: simplify bootstrap.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ def get_env_var(name: str, default: Optional[str] = None) -> Optional[str]:
 ## Make Your AI Learn Your Style in 2 Minutes
 
 ```bash
-# One command to teach your AI your style (30 seconds)
+# One simple command to teach your AI your style (30 seconds)
 curl -LsSf https://raw.githubusercontent.com/safurrier/cookiecutter-ai-conventions/main/bootstrap.sh | sh
+
+# The bootstrap script simply:
+# 1. Installs uv if needed
+# 2. Runs cookiecutter to set up your conventions
 
 # That's it! Your AI now knows:
 # ✓ Your import style
@@ -152,16 +156,28 @@ One command, zero dependencies:
 curl -LsSf https://raw.githubusercontent.com/safurrier/cookiecutter-ai-conventions/main/bootstrap.sh | sh
 ```
 
-This will:
-- ✅ Install `uv` if needed (cross-platform)
-- ✅ Run the cookiecutter template
-- ✅ Guide you through setup
-- ✅ Provide next steps
+The bootstrap script is simple and straightforward - it just:
+- ✅ Installs `uv` if needed (the modern Python package manager)
+- ✅ Runs cookiecutter to generate your conventions repository
 
 **Provider Selection:** When prompted, enter one or more providers separated by commas:
 - Single: `claude`
 - Multiple: `claude,cursor,windsurf`
 - All: `claude,cursor,windsurf,aider,copilot,codex`
+
+### Windows Installation
+
+Windows users should use PowerShell:
+
+```powershell
+# Install uv first (see https://docs.astral.sh/uv/getting-started/installation/#windows)
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Then run cookiecutter
+uvx cookiecutter gh:safurrier/cookiecutter-ai-conventions
+```
+
+For detailed Windows installation options, see the [uv installation docs](https://docs.astral.sh/uv/getting-started/installation/#windows).
 
 ### Manual Installation
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,140 +1,28 @@
 #!/bin/bash
-# bootstrap.sh - Zero-dependency installer for cookiecutter-ai-conventions
+# bootstrap.sh - Installer for cookiecutter-ai-conventions
 
 set -e
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-echo -e "${BLUE}🚀 Cookiecutter AI Conventions Installer${NC}"
-echo "======================================="
-echo
-
-# Function to detect OS
-detect_os() {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        echo "linux"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        echo "macos"
-    elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
-        echo "windows"
-    else
-        echo "unknown"
-    fi
-}
-
-# Function to check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
-
-# Check for uv
-if ! command_exists uv; then
-    echo -e "${YELLOW}📦 Installing uv package manager...${NC}"
+# Check if uv is installed
+if ! command -v uv >/dev/null 2>&1; then
+    echo "Installing uv package manager..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     
-    OS=$(detect_os)
-    
-    if [[ "$OS" == "windows" ]]; then
-        # Windows installation
-        echo "Detected Windows environment"
-        if command_exists powershell; then
-            powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-        else
-            echo -e "${RED}❌ PowerShell not found. Please install uv manually:${NC}"
-            echo "   https://github.com/astral-sh/uv"
-            exit 1
-        fi
-    else
-        # Unix-like installation (macOS, Linux)
-        echo "Detected Unix-like environment ($OS)"
-        if command_exists curl; then
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-        elif command_exists wget; then
-            wget -qO- https://astral.sh/uv/install.sh | sh
-        else
-            echo -e "${RED}❌ Neither curl nor wget found. Please install one of them first.${NC}"
-            exit 1
-        fi
-        
-        # Add to PATH for current session
-        export PATH="$HOME/.cargo/bin:$PATH"
-        
-        # Source shell config if available
-        if [[ -f "$HOME/.bashrc" ]]; then
-            source "$HOME/.bashrc"
-        elif [[ -f "$HOME/.zshrc" ]]; then
-            source "$HOME/.zshrc"
-        fi
-    fi
-    
-    # Verify installation
-    if ! command_exists uv; then
-        echo -e "${RED}❌ Failed to install uv${NC}"
-        echo "Please install manually from: https://github.com/astral-sh/uv"
-        exit 1
-    fi
-    
-    echo -e "${GREEN}✅ uv installed successfully${NC}"
-else
-    echo -e "${GREEN}✅ uv is already installed${NC}"
+    # Add to PATH for current session
+    export PATH="$HOME/.cargo/bin:$PATH"
 fi
 
-# Parse command line arguments
-BRANCH=""
-EXTRA_ARGS=""
+# Run cookiecutter with all arguments passed through
+echo "Creating your AI conventions repository..."
+uvx cookiecutter gh:safurrier/cookiecutter-ai-conventions "$@"
 
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --branch=*)
-            BRANCH="${1#*=}"
-            shift
-            ;;
-        *)
-            EXTRA_ARGS="$EXTRA_ARGS $1"
-            shift
-            ;;
-    esac
-done
-
-# Run cookiecutter
-echo
-echo -e "${YELLOW}📝 Creating your AI conventions repository...${NC}"
-echo
-
-# Build the command
-if [[ -n "$BRANCH" ]]; then
-    echo "Using branch: $BRANCH"
-    COOKIECUTTER_CMD="uvx cookiecutter gh:safurrier/cookiecutter-ai-conventions --checkout \"$BRANCH\"$EXTRA_ARGS"
-else
-    COOKIECUTTER_CMD="uvx cookiecutter gh:safurrier/cookiecutter-ai-conventions$EXTRA_ARGS"
-fi
-
-# Execute cookiecutter
-eval $COOKIECUTTER_CMD
-
-# Check if cookiecutter succeeded
+# Show next steps if successful
 if [[ $? -eq 0 ]]; then
     echo
-    echo -e "${GREEN}✨ Success! Your AI conventions repository is ready.${NC}"
+    echo "Success! Your AI conventions repository is ready."
     echo
     echo "Next steps:"
     echo "  1. cd into your new repository"
     echo "  2. Run 'uv tool install .' to install CLI commands"
     echo "  3. Run 'ai-conventions status' to check your setup"
-    echo "  4. Start capturing your conventions!"
-    echo
-    echo "Quick start:"
-    echo -e "  ${BLUE}cd <your-project-name>${NC}"
-    echo -e "  ${BLUE}uv tool install .${NC}"
-    echo -e "  ${BLUE}ai-conventions status${NC}"
-    echo
-else
-    echo
-    echo -e "${RED}❌ Failed to create repository${NC}"
-    echo "Please check the error messages above"
-    exit 1
 fi

--- a/tests/test_bootstrap_script.py
+++ b/tests/test_bootstrap_script.py
@@ -39,18 +39,18 @@ def test_bootstrap_script_has_error_handling():
     assert "command -v" in content or "which" in content
 
 
-def test_bootstrap_script_supports_os_detection():
-    """Test that bootstrap.sh can detect different operating systems."""
+def test_bootstrap_script_is_simple():
+    """Test that bootstrap.sh is simple and focused."""
     bootstrap_script = Path("bootstrap.sh")
     content = bootstrap_script.read_text(encoding="utf-8")
     
-    # Should detect OS
-    assert "OSTYPE" in content or "uname" in content
+    # Should be a simple script
+    lines = content.strip().split('\n')
+    assert len(lines) < 30, "Bootstrap script should be simple and concise"
     
-    # Should handle different OS types
-    assert "linux" in content.lower()
-    assert "macos" in content.lower() or "darwin" in content.lower()
-    assert "windows" in content.lower() or "msys" in content.lower()
+    # Should not have complex OS detection
+    assert "OSTYPE" not in content
+    assert "detect_os" not in content
 
 
 def test_bootstrap_script_installs_uv():
@@ -59,14 +59,13 @@ def test_bootstrap_script_installs_uv():
     content = bootstrap_script.read_text(encoding="utf-8")
     
     # Should check for uv
-    assert "uv" in content
+    assert "command -v uv" in content
     
-    # Should have installation URLs
-    assert "https://astral.sh/uv" in content or "astral.sh" in content
+    # Should have installation URL
+    assert "https://astral.sh/uv/install.sh" in content
     
-    # Should handle both curl and wget
-    assert "curl" in content
-    assert "wget" in content
+    # Should use curl for installation
+    assert "curl -LsSf" in content
 
 
 def test_bootstrap_script_runs_cookiecutter():
@@ -82,30 +81,26 @@ def test_bootstrap_script_runs_cookiecutter():
     assert "safurrier/cookiecutter-ai-conventions" in content
 
 
-def test_bootstrap_script_supports_branch_parameter():
-    """Test that bootstrap.sh supports --branch parameter."""
+def test_bootstrap_script_passes_arguments():
+    """Test that bootstrap.sh passes all arguments to cookiecutter."""
     bootstrap_script = Path("bootstrap.sh")
     content = bootstrap_script.read_text(encoding="utf-8")
     
-    # Should parse branch parameter
-    assert "--branch" in content
-    assert "--checkout" in content
+    # Should pass all arguments using $@
+    assert '"$@"' in content
 
 
-def test_bootstrap_script_has_user_friendly_output():
-    """Test that bootstrap.sh has nice output formatting."""
+def test_bootstrap_script_has_clear_output():
+    """Test that bootstrap.sh has clear output messages."""
     bootstrap_script = Path("bootstrap.sh")
     content = bootstrap_script.read_text(encoding="utf-8")
     
-    # Should have colors
-    assert "033[" in content or "\\033[" in content
+    # Should have clear messages
+    assert "Installing uv package manager" in content
+    assert "Creating your AI conventions repository" in content
     
-    # Should have emojis
-    assert "🚀" in content or "✅" in content or "❌" in content
-    
-    # Should have clear success/failure messages
+    # Should have success message
     assert "Success" in content or "success" in content
-    assert "Failed" in content or "failed" in content or "Error" in content
 
 
 def test_bootstrap_script_provides_next_steps():


### PR DESCRIPTION
## Summary
- Simplified bootstrap.sh from 140 lines to 28 lines
- Removed complex OS detection and edge case handling
- Script now just installs uv if needed and runs cookiecutter

## Motivation
The bootstrap script was overengineered for most use cases. The simplified version:
- Is easier to understand and maintain
- Less likely to break across different environments  
- Focuses on the core functionality

Users who need advanced features (like Windows PowerShell support) can follow the manual installation instructions in the README.

## Changes
- Replaced bootstrap.sh with minimal version
- Updated README to document both simple and manual installation options
- Updated tests to match simplified script behavior

## Test Plan
- [x] Ran `make check` - all tests pass
- [x] Verified bootstrap script syntax is valid
- [x] Confirmed simplified script still provides core functionality

Fixes #60