### PR TITLE
fix: resolve installation issues with bootstrap and uv tool install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,21 +3,30 @@
 
 set -e
 
-# Check if uv is installed
-if ! command -v uv >/dev/null 2>&1; then
-    echo "Installing uv package manager..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    
-    # Add to PATH for current session
-    export PATH="$HOME/.cargo/bin:$PATH"
-fi
+# Function to ensure uv is available
+ensure_uv() {
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "Installing uv package manager..."
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        
+        # Add to PATH for current session
+        export PATH="$HOME/.cargo/bin:$PATH"
+        export PATH="$HOME/.local/bin:$PATH"
+        
+        # Verify installation
+        if ! command -v uv >/dev/null 2>&1; then
+            echo "Error: uv installation failed"
+            exit 1
+        fi
+    fi
+}
+
+# Ensure uv is available
+ensure_uv
 
 # Run cookiecutter with all arguments passed through
 echo "Creating your AI conventions repository..."
-uvx cookiecutter gh:safurrier/cookiecutter-ai-conventions "$@"
-
-# Show next steps if successful
-if [[ $? -eq 0 ]]; then
+if uv tool run cookiecutter gh:safurrier/cookiecutter-ai-conventions "$@"; then
     echo
     echo "Success! Your AI conventions repository is ready."
     echo

--- a/{{cookiecutter.project_slug}}/ai_conventions/capture.py
+++ b/{{cookiecutter.project_slug}}/ai_conventions/capture.py
@@ -15,7 +15,7 @@ console = Console()
 @click.option("--domain", "-d", help="Target domain for this learning")
 @click.option("--file", "-f", help="Append to specific file in staging")
 @click.option("--category", "-c", help="Category of learning (fix, pattern, etc)")
-def main(pattern, domain, file, category):
+def capture_command(pattern, domain, file, category):
     """Capture a new learning or pattern.
     
     Examples:
@@ -95,4 +95,4 @@ def main(pattern, domain, file, category):
 
 
 if __name__ == "__main__":
-    main()
+    capture_command()

--- a/{{cookiecutter.project_slug}}/ai_conventions/cli.py
+++ b/{{cookiecutter.project_slug}}/ai_conventions/cli.py
@@ -8,14 +8,17 @@ from rich.table import Table
 console = Console()
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.version_option(version="0.1.0", prog_name="ai-conventions")
-def main():
+@click.pass_context
+def main(ctx):
     """AI Conventions management tool.
     
     Manage your AI development conventions across multiple tools.
     """
-    pass
+    # Show help if no command provided
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @main.command()
@@ -94,4 +97,36 @@ def list():
 
 
 if __name__ == "__main__":
+    # Import subcommands when running as main module
+    {%- if cookiecutter.enable_learning_capture %}
+    from .capture import capture_command
+    from .sync import sync_command
+    {%- else %}
+    from .sync import sync_command
+    {%- endif %}
+    from .config_cli import config_command
+    
+    # Add subcommands
+    {%- if cookiecutter.enable_learning_capture %}
+    main.add_command(capture_command, name="capture")
+    {%- endif %}
+    main.add_command(sync_command, name="sync")
+    main.add_command(config_command, name="config")
+    
     main()
+else:
+    # Import subcommands when imported as module
+    {%- if cookiecutter.enable_learning_capture %}
+    from .capture import capture_command
+    from .sync import sync_command
+    {%- else %}
+    from .sync import sync_command
+    {%- endif %}
+    from .config_cli import config_command
+    
+    # Add subcommands
+    {%- if cookiecutter.enable_learning_capture %}
+    main.add_command(capture_command, name="capture")
+    {%- endif %}
+    main.add_command(sync_command, name="sync")
+    main.add_command(config_command, name="config")

--- a/{{cookiecutter.project_slug}}/ai_conventions/config_cli.py
+++ b/{{cookiecutter.project_slug}}/ai_conventions/config_cli.py
@@ -7,12 +7,12 @@ from ai_conventions.config import ConfigManager, ConventionsConfig
 
 
 @click.group()
-def config():
+def config_command():
     """Manage AI conventions configuration."""
     pass
 
 
-@config.command()
+@config_command.command()
 @click.option(
     "--format", "-f",
     type=click.Choice(["yaml", "toml", "json"]),
@@ -53,7 +53,7 @@ def show(format, path):
         click.echo(f"Error loading config: {e}", err=True)
 
 
-@config.command()
+@config_command.command()
 @click.option(
     "--path", "-p",
     type=click.Path(),
@@ -74,7 +74,7 @@ def validate(path):
             click.echo(f"  - {error}", err=True)
 
 
-@config.command()
+@config_command.command()
 @click.argument("source", type=click.Path(exists=True))
 @click.argument("target_format", type=click.Choice(["yaml", "toml", "json"]))
 @click.option(
@@ -96,7 +96,7 @@ def migrate(source, target_format, output):
         click.echo(f"✗ Migration failed: {e}", err=True)
 
 
-@config.command()
+@config_command.command()
 @click.option(
     "--format", "-f",
     type=click.Choice(["yaml", "toml", "json"]),
@@ -146,7 +146,7 @@ def init(format, path, project_name, author_name, providers):
 
 def main():
     """Run config CLI."""
-    config()
+    config_command()
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/ai_conventions/sync.py
+++ b/{{cookiecutter.project_slug}}/ai_conventions/sync.py
@@ -93,7 +93,7 @@ PROVIDERS = {
 @click.command()
 @click.option("--provider", "-p", multiple=True, help="Specific provider(s) to sync")
 @click.option("--all", "sync_all", is_flag=True, help="Sync to all configured providers")
-def main(provider, sync_all):
+def sync_command(provider, sync_all):
     """Sync conventions to AI tool providers.
     
     Examples:
@@ -163,4 +163,4 @@ def main(provider, sync_all):
 
 
 if __name__ == "__main__":
-    main()
+    sync_command()

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -23,11 +23,9 @@ dependencies = [
 
 [project.scripts]
 ai-conventions = "ai_conventions.cli:main"
-{%- if cookiecutter.enable_learning_capture %}
-capture-learning = "ai_conventions.capture:main"
-{%- endif %}
-sync-conventions = "ai_conventions.sync:main"
-conventions-config = "ai_conventions.config_cli:main"
+
+[tool.setuptools]
+packages = ["ai_conventions"]
 
 [tool.uv]
 dev-dependencies = [


### PR DESCRIPTION
## Summary
- Fixed bootstrap script to properly handle uv installation and use correct command syntax
- Resolved "Multiple top-level packages discovered" error when running `uv tool install .`
- Simplified CLI to single entry point with subcommands instead of multiple tools

## Problem
Users reported two main issues:
1. Bootstrap script had problems with user input during cookiecutter prompts
2. `uv tool install .` failed with setuptools package discovery error

## Solution

### Bootstrap Script
- Added proper uv installation verification
- Fixed PATH handling for both `.cargo/bin` and `.local/bin` 
- Changed to use `uv tool run cookiecutter` for better compatibility

### Package Installation
- Added `[tool.setuptools]` section with `packages = ["ai_conventions"]`
- This explicitly tells setuptools which package to include
- Prevents automatic discovery of non-package directories like `domains/`, `staging/`, etc.

### CLI Simplification
- Changed from 4 separate tools to single `ai-conventions` command with subcommands
- New structure:
  - `ai-conventions status` - Check installation status
  - `ai-conventions list` - List domains
  - `ai-conventions capture` - Capture learnings (if enabled)
  - `ai-conventions sync` - Sync to providers
  - `ai-conventions config` - Manage configuration
- This also fixes the PosixPath TypeError that was occurring with multiple entry points

## Test Plan
- [x] Bootstrap script properly installs uv
- [x] `uv tool install .` works without package discovery errors
- [x] Single CLI tool with subcommands is cleaner UX
- [ ] Manual testing of generated project installation

Fixes #62